### PR TITLE
Fix CI by using npm exec in build.rs

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.thumbv7em-none-eabihf]
-runner = 'npx --yes -- nwlink@0.0.15 install-nwa'
+runner = 'npm exec --yes -- nwlink@0.0.15 install-nwa'
 rustflags = ["-C", "link-arg=--relocatable", "-C", "link-arg=-no-gc-sections"]
 
 [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [pull_request, push]
+on: [pull_request, push, workflow_dispatch]
 
 jobs:
   build:

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,21 @@ use std::process::Command;
 fn main() {
     // Turn icon.png into icon.nwi
     println!("cargo:rerun-if-changed=src/icon.png");
-    let output = Command::new("nwlink")
-        .args(&["png-nwi", "src/icon.png", "target/icon.nwi"])
-        .output().expect("Failure to launch process");
-    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let output = Command::new("npm")
+        .args(&[
+            "exec",
+            "--yes",
+            "--",
+            "nwlink",
+            "png-nwi",
+            "src/icon.png",
+            "target/icon.nwi",
+        ])
+        .output()
+        .expect("Failure to launch process");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }


### PR DESCRIPTION
Replace deprecated `npx` by `npm exec`, see [the npx repo](https://github.com/npm/npx) and [npm docs on npx vs npm exec](https://docs.npmjs.com/cli/v9/commands/npm-exec#npx-vs-npm-execl).
Fix the CI by running `npm exec --yes -- nwlink png-nwi src/icon.png target/icon.nwi`.
Used `workflow_dispatch` to trigger the workflow manually.